### PR TITLE
--select-columns

### DIFF
--- a/scrubcsv/CHANGELOG.md
+++ b/scrubcsv/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] - 2025-03-04
+
+### Added
+
+- Added `--select-columns` which accepts a CSV of headers (in their final post-processed form) and only returns those headers. While this is technically redundant with `xsv select`, it allows earlier field selection when processing very large files.
+
 ## [1.0.0] - 2022-05-25
 
 ### Added

--- a/scrubcsv/src/main.rs
+++ b/scrubcsv/src/main.rs
@@ -9,6 +9,7 @@ use log::debug;
 use regex::{bytes::Regex as BytesRegex, Regex};
 use std::{
     borrow::Cow,
+    collections::HashSet,
     fs,
     io::{self, prelude::*},
     path::PathBuf,
@@ -282,6 +283,12 @@ fn run() -> Result<()> {
                     col
                 ));
             }
+        }
+        let mut seen = HashSet::new();
+        if !selected_columns_vec.iter().all(|x| seen.insert(x)) {
+            return Err(format_err!(
+                "--select-columns cannot contain duplicate column names"
+            ));
         }
 
         // The positions of selected columns in the original header

--- a/scrubcsv/src/main.rs
+++ b/scrubcsv/src/main.rs
@@ -392,7 +392,7 @@ fn run() -> Result<()> {
         } else {
             // We need to apply one or more cleanups, so run the slow path.
             // Process each column, but only keep selected columns if specified
-            let mut cleaned = if !selected_cols.is_none() {
+            let mut cleaned = if selected_cols.is_some() {
                 Vec::with_capacity(selected_cols_len)
             } else {
                 Vec::with_capacity(record.len())

--- a/scrubcsv/src/util.rs
+++ b/scrubcsv/src/util.rs
@@ -20,7 +20,7 @@ impl FromStr for CharSpecifier {
     type Err = Error;
 
     fn from_str(s: &str) -> Result<CharSpecifier> {
-        if s.as_bytes().len() == 1 {
+        if s.len() == 1 {
             Ok(CharSpecifier(Some(s.as_bytes()[0])))
         } else {
             match s {

--- a/scrubcsv/tests/tests.rs
+++ b/scrubcsv/tests/tests.rs
@@ -256,3 +256,44 @@ a,b,c
 "#
     );
 }
+
+#[test]
+fn select_columns() {
+    let testdir = TestDir::new("scrubcsv", "select_columns");
+    let output = testdir
+        .cmd()
+        .arg("--select-columns=c1,c3")
+        .output_with_stdin(
+            r#"c1,c2,c3
+a,b,c
+d,e,f
+g,h,i
+"#,
+        )
+        .expect("error running scrubcsv");
+    eprintln!("{}", output.stderr_str());
+    assert_eq!(
+        output.stdout_str(),
+        r#"c1,c3
+a,c
+d,f
+g,i
+"#
+    );
+}
+
+#[test]
+fn select_columns_error_if_selected_columns_are_not_in_header() {
+    let testdir = TestDir::new(
+        "scrubcsv",
+        "select_columns_error_if_selected_columns_are_not_in_header",
+    );
+    let output = testdir
+        .cmd()
+        .arg("--select-columns=a,b")
+        .output_with_stdin(r#"c1,c2,c3"#)
+        .expect_failure();
+    assert!(output
+        .stderr_str()
+        .contains("The provided CSV of headers does not contain the column \"a\""));
+}

--- a/scrubcsv/tests/tests.rs
+++ b/scrubcsv/tests/tests.rs
@@ -312,17 +312,6 @@ c1-3,c2-3,c3-3,c4-3,c5-3
 "#,
         )
         .expect("error running scrubcsv");
-    eprintln!("{}", output.stderr_str());
-    eprintln!("got");
-    eprintln!("{}", output.stdout_str());
-    eprintln!("expected");
-    eprintln!(
-        "c5,c2,c4
-c5-1,c2-1,c4-1
-c5-2,c2-2,c4-2
-c5-3,c2-3,c4-3
-"
-    );
     assert_eq!(
         output.stdout_str(),
         r#"c5,c2,c4
@@ -331,4 +320,23 @@ c5-2,c2-2,c4-2
 c5-3,c2-3,c4-3
 "#
     );
+}
+
+#[test]
+fn select_columns_handles_duplicate_selected_columns() {
+    let testdir = TestDir::new("scrubcsv", "select_columns");
+    let output = testdir
+        .cmd()
+        .arg("--select-columns=c5,c5,c4")
+        .output_with_stdin(
+            r#"c1,c2,c3,c4,c5
+c1-1,c2-1,c3-1,c4-1,c5-1
+c1-2,c2-2,c3-2,c4-2,c5-2
+c1-3,c2-3,c3-3,c4-3,c5-3
+"#,
+        )
+        .expect_failure();
+    assert!(output
+        .stderr_str()
+        .contains("--select-columns cannot contain duplicate column names"));
 }

--- a/scrubcsv/tests/tests.rs
+++ b/scrubcsv/tests/tests.rs
@@ -297,3 +297,39 @@ fn select_columns_error_if_selected_columns_are_not_in_header() {
         .stderr_str()
         .contains("The provided CSV of headers does not contain the column \"a\""));
 }
+
+#[test]
+fn select_columns_respects_order() {
+    let testdir = TestDir::new("scrubcsv", "select_columns");
+    let output = testdir
+        .cmd()
+        .arg("--select-columns=c5,c2,c4")
+        .output_with_stdin(
+            r#"c1,c2,c3,c4,c5
+c1-1,c2-1,c3-1,c4-1,c5-1
+c1-2,c2-2,c3-2,c4-2,c5-2
+c1-3,c2-3,c3-3,c4-3,c5-3
+"#,
+        )
+        .expect("error running scrubcsv");
+    eprintln!("{}", output.stderr_str());
+    eprintln!("got");
+    eprintln!("{}", output.stdout_str());
+    eprintln!("expected");
+    eprintln!(
+        "{}",
+        r#"c5,c2,c4
+c5-1,c2-1,c4-1
+c5-2,c2-2,c4-2
+c5-3,c2-3,c4-3
+"#
+    );
+    assert_eq!(
+        output.stdout_str(),
+        r#"c5,c2,c4
+c5-1,c2-1,c4-1
+c5-2,c2-2,c4-2
+c5-3,c2-3,c4-3
+"#
+    );
+}

--- a/scrubcsv/tests/tests.rs
+++ b/scrubcsv/tests/tests.rs
@@ -47,7 +47,7 @@ fn stdin_and_delimiter_and_quiet() {
     let testdir = TestDir::new("scrubcsv", "stdin_and_delimiter_and_quiet");
     let output = testdir
         .cmd()
-        .args(&["-d", "|"])
+        .args(["-d", "|"])
         .arg("-q")
         .output_with_stdin(
             "\
@@ -78,8 +78,8 @@ a\tb\tc
     );
     let output = testdir
         .cmd()
-        .args(&["-d", r"\t"])
-        .args(&["--quote", "none"])
+        .args(["-d", r"\t"])
+        .args(["--quote", "none"])
         .arg("in.csv")
         .expect_success();
     assert_eq!(
@@ -133,7 +133,7 @@ fn null_normalization() {
     let testdir = TestDir::new("scrubcsv", "null_normalization");
     let output = testdir
         .cmd()
-        .args(&["--null", "(?i)null|NIL"])
+        .args(["--null", "(?i)null|NIL"])
         .output_with_stdin("a,b,c,d,e\nnull,NIL,nil,,not null\n")
         .expect_success();
     assert_eq!(output.stdout_str(), "a,b,c,d,e\n,,,,not null\n")
@@ -144,7 +144,7 @@ fn null_normalization_of_null_bytes() {
     let testdir = TestDir::new("scrubcsv", "null_normalization_of_null_bytes");
     let output = testdir
         .cmd()
-        .args(&["--null", "\\x00"])
+        .args(["--null", "\\x00"])
         .output_with_stdin("a,b\n\0,\n")
         .expect_success();
     assert_eq!(output.stdout_str(), "a,b\n,\n")
@@ -237,7 +237,7 @@ fn drop_row_if_null() {
         .cmd()
         .arg("--drop-row-if-null=c1")
         .arg("--drop-row-if-null=c2")
-        .args(&["--null", "NULL"])
+        .args(["--null", "NULL"])
         .output_with_stdin(
             r#"c1,c2,c3
 1,,
@@ -317,12 +317,11 @@ c1-3,c2-3,c3-3,c4-3,c5-3
     eprintln!("{}", output.stdout_str());
     eprintln!("expected");
     eprintln!(
-        "{}",
-        r#"c5,c2,c4
+        "c5,c2,c4
 c5-1,c2-1,c4-1
 c5-2,c2-2,c4-2
 c5-3,c2-3,c4-3
-"#
+"
     );
     assert_eq!(
         output.stdout_str(),


### PR DESCRIPTION
technically redundant with `xsv select`, but sometimes when processing very large files you don't want to emit all that data to a pipeline just to immediately discard it