### PR TITLE
enhancement(scrubcsv): add new output-stats flag for outputting stats to file

### DIFF
--- a/scrubcsv/src/main.rs
+++ b/scrubcsv/src/main.rs
@@ -130,8 +130,8 @@ struct Opt {
 
     /// Format for the statistics output file. Only valid with --output-stats.
     /// 'json' outputs structured data, 'text' outputs human-readable format.
-    #[structopt(long = "output-format", default_value = "json", requires = "output-stats")]
-    output_format: OutputFormat,
+    #[structopt(long = "output-format", requires = "output-stats")]
+    output_format: Option<OutputFormat>,
 
     /// Character used to quote entries. May be set to "none" to ignore all
     /// quoting.
@@ -399,7 +399,8 @@ fn run() -> Result<()> {
                 .with_context(|_| format!("cannot create output file {}", output_path.display()))?
         );
 
-        let stats_content = match opt.output_format {
+        let format = opt.output_format.unwrap_or(OutputFormat::Json);
+        let stats_content = match format {
             OutputFormat::Json => {
                 format!(
                     r#"{{"rows": {}, "bad_rows": {}, "elapsed_seconds": {:.2}, "bytes_per_second": {}}}"#,


### PR DESCRIPTION
  - Added --output-stats (-o) flag to output performance statistics to a file
  - Added --output-format flag with JSON and text options
  - Made --output-format only valid when used with --output-stats
  - Provided clear descriptions in the help output
  - Maintained existing stderr logging behavior